### PR TITLE
added option to enable debugging

### DIFF
--- a/distributeblocks/Node.java
+++ b/distributeblocks/Node.java
@@ -214,11 +214,7 @@ public class Node {
 		return wallet;
 	}
 
-	public static void main (String[] args){
-		// Begin the console for logging
-		Console.start();
-		Console.log("Beginning node processes");
-		
+	public static void main (String[] args){		
 		// Initialize this node
 		Node node = new Node();
 		NodeService.init(node);

--- a/distributeblocks/cli/StartHandler.java
+++ b/distributeblocks/cli/StartHandler.java
@@ -3,6 +3,7 @@ package distributeblocks.cli;
 import java.util.concurrent.Callable;
 
 import distributeblocks.Node;
+import distributeblocks.io.Console;
 import distributeblocks.net.IPAddress;
 import distributeblocks.net.NetworkConfig;
 import picocli.CommandLine.Command;
@@ -25,7 +26,7 @@ public class StartHandler implements Callable<Void> {
 	
 	@Option(names = {"-p", "--port"}, 
 			description = "The port to open on")
-	private int port = 5832;
+	private int port = 5833;
 	
 	@Option(names = {"-sAddr", "--seedAddress"}, 
 			description = "The IP address of a seed node")
@@ -51,12 +52,21 @@ public class StartHandler implements Callable<Void> {
 			description = "The full peer config file path. Eg: ./blockchain.txt")
 	private String blockFile = "./blockchain.txt";
 	
+	@Option(names = {"--debug"},
+			description = "Enable or disable seperate debugging console")
+	private boolean debug = false;
+	
 	public StartHandler(Node node) {
 		this.node = node;
 	}
 	
 	@Override
 	public Void call() throws Exception {
+		if (debug) {
+			Console.start();
+			Console.log("Beginning node processes");
+		}
+		
 		NetworkConfig config = new NetworkConfig();
 		config.maxPeers = maxPeers;
 		config.minPeers = minPeers;

--- a/distributeblocks/io/Console.java
+++ b/distributeblocks/io/Console.java
@@ -32,6 +32,10 @@ public class Console {
 	 * Log a string to the console.
 	 */
 	public static synchronized void log(String s) {
-		consoleWindow.log(s);
+		if (consoleWindow != null)
+			consoleWindow.log(s);
+		else
+			return;
+//			System.out.println(s);
 	}
 }


### PR DESCRIPTION
The option to enable the debugging console was added so that a user can opt not to launch the additional console. This is also useful for starting remote seed nodes which have no display enabled.

The debugging console is now disabled by default, and can be enabled with the --debug option of the start command.